### PR TITLE
Dbatiste/create tests

### DIFF
--- a/d2l-menu.html
+++ b/d2l-menu.html
@@ -353,8 +353,10 @@
 					}
 				}
 
-				Polymer.dom(visibleItems[0]).classList.add('d2l-menu-item-first');
-				Polymer.dom(visibleItems[visibleItems.length - 1]).classList.add('d2l-menu-item-last');
+				if (visibleItems.length > 0) {
+					Polymer.dom(visibleItems[0]).classList.add('d2l-menu-item-first');
+					Polymer.dom(visibleItems[visibleItems.length - 1]).classList.add('d2l-menu-item-last');
+				}
 
 			},
 

--- a/d2l-menu.html
+++ b/d2l-menu.html
@@ -181,13 +181,17 @@
 
 			_getMenuItems: function() {
 				var items = this.getEffectiveChildren();
-				var returnItem = this.$$('d2l-menu-item-return');
+				var returnItem = this._getMenuItemReturn();
 				if (returnItem) {
 					items.unshift(returnItem);
 				}
 				return items.filter(function(item) {
 					return (item.getAttribute('role') === 'menuitem');
 				});
+			},
+
+			_getMenuItemReturn: function() {
+				return this.$$('d2l-menu-item-return');
 			},
 
 			_isFocusable: function(item) {

--- a/d2l-menu.html
+++ b/d2l-menu.html
@@ -273,6 +273,7 @@
 					return itemIndex + 1;
 				}.bind(this);
 
+				/* "charCode" is used instead of "key" due to Safari not supporting */
 				var searchChar = String.fromCharCode(e.charCode);
 
 				var itemIndex = getNextOrFirstIndex(targetItemIndex);

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,9 @@
 		<script>
 		WCT.loadSuites([
 			'menu.html',
-			'menu.html?dom=shadow'
+			'menu.html?dom=shadow',
+			'menu-item.html',
+			'menu-item.html?dom=shadow'
 		]);
 		</script>
 	</body>

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,9 @@
 			'menu.html',
 			'menu.html?dom=shadow',
 			'menu-item.html',
-			'menu-item.html?dom=shadow'
+			'menu-item.html?dom=shadow',
+			'menu-item-separator.html',
+			'menu-item-separator.html?dom=shadow'
 		]);
 		</script>
 	</body>

--- a/test/menu-item-separator.html
+++ b/test/menu-item-separator.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>d2l-menu-item-separator tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+		<link rel="import" href="../d2l-menu.html">
+	</head>
+	<body>
+
+		<test-fixture id="separator">
+			<template>
+				<d2l-menu-item-separator></d2l-menu-item-separator>
+			</template>
+		</test-fixture>
+
+		<script>
+
+		describe('<d2l-menu-item-separator>', function() {
+
+			var separator;
+
+			beforeEach(function() {
+				separator = fixture('separator');
+			});
+
+			it('has role="separator"', function() {
+				expect(separator.getAttribute('role')).to.equal('separator');
+			});
+
+		});
+		</script>
+	</body>
+</html>

--- a/test/menu-item.html
+++ b/test/menu-item.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>d2l-menu-item tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+		<link rel="import" href="../d2l-menu.html">
+	</head>
+	<body>
+
+		<test-fixture id="menu">
+			<template>
+				<d2l-menu id="menu">
+					<d2l-menu-item id="a1"></d2l-menu-item>
+					<d2l-menu-item id="b1">
+						<d2l-menu id="nestedMenu">
+							<d2l-menu-item id="a2"></d2l-menu-item>
+							<d2l-menu-item id="b2"></d2l-menu-item>
+						</d2l-menu>
+					</d2l-menu-item>
+					<d2l-menu-item id="c1" disabled></d2l-menu-item>
+				</d2l-menu>
+			</template>
+		</test-fixture>
+
+		<script>
+
+		describe('<d2l-menu-item>', function() {
+
+			var menu;
+
+			beforeEach(function() {
+				menu = fixture('menu');
+			});
+
+			it('has role="menuitem"', function() {
+				expect(menu.querySelector('#a1').getAttribute('role')).to.equal('menuitem');
+			});
+
+			it('has aria-haspopup="true" when item contains nested menu', function() {
+				expect(menu.querySelector('#b1').getAttribute('aria-haspopup')).to.equal('true');
+			});
+
+			it('fires select event when item is clicked', function(done) {
+				menu.addEventListener('select', function(e) {
+					expect(e.target.id).to.equal('a1');
+					done();
+				});
+				menu.querySelector('#a1').click();
+			});
+
+			it('fires select event when enter key pressed on item', function(done) {
+				menu.addEventListener('select', function(e) {
+					expect(e.target.id).to.equal('a1');
+					done();
+				});
+				MockInteractions.keyDownOn(menu.querySelector('#a1'), 13);
+			});
+
+			it('fires select event when space key pressed on item', function(done) {
+				menu.addEventListener('select', function(e) {
+					expect(e.target.id).to.equal('a1');
+					done();
+				});
+				MockInteractions.keyDownOn(menu.querySelector('#a1'), 32);
+			});
+
+			it('does not fire select event for disabled item', function(done) {
+				var fired = false;
+				menu.addEventListener('select', function(e) {
+					fired = true;
+				});
+				setTimeout(function() {
+					expect(fired).to.be.false;
+					done();
+				}, 0);
+				MockInteractions.keyDownOn(menu.querySelector('#c1'), 13);
+			});
+
+		});
+		</script>
+	</body>
+</html>

--- a/test/menu.html
+++ b/test/menu.html
@@ -94,7 +94,11 @@
 
 				it('sets focus to d2l-menu-item-return when nested menu is displayed', function(done) {
 					menu.addEventListener('show-complete', function() {
-						expect(document.activeElement.tagName).to.equal('D2L-MENU-ITEM-RETURN');
+						var focused = (document.activeElement.tagName === 'D2L-MENU-ITEM-RETURN');
+						if (!focused) {
+							focused = (document.activeElement === menu.querySelector('#nestedMenu'));
+						}
+						expect(focused).to.be.true;
 						done();
 					});
 					menu.querySelector('#b1').click();
@@ -136,7 +140,8 @@
 						done();
 					});
 					menu.addEventListener('show-complete', function() {
-						document.activeElement.click();
+						var returnItem = menu.querySelector('#nestedMenu')._getMenuItemReturn();
+						returnItem.click();
 					});
 					menu.querySelector('#b1').click();
 				});

--- a/test/menu.html
+++ b/test/menu.html
@@ -11,12 +11,206 @@
 	</head>
 	<body>
 
+		<test-fixture id="basicMenu">
+			<template>
+				<d2l-menu id="menu" label="menu label">
+					<d2l-menu-item></d2l-menu-item>
+					<d2l-menu-item></d2l-menu-item>
+				</d2l-menu>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="focusMenu">
+			<template>
+				<d2l-menu id="menu">
+					<d2l-menu-item id="hidden_a" text="a" hidden></d2l-menu-item>
+					<d2l-menu-item id="a1" text="a"></d2l-menu-item>
+					<d2l-menu-item id="b1" text="b" disabled></d2l-menu-item>
+					<d2l-menu-item id="a2" text="a"></d2l-menu-item>
+					<d2l-menu-item id="c1" text="c"></d2l-menu-item>
+					<d2l-menu-item id="d1" text="d"></d2l-menu-item>
+				</d2l-menu>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="nestedMenu">
+			<template>
+				<d2l-menu id="menu">
+					<d2l-menu-item id="a1"></d2l-menu-item>
+					<d2l-menu-item id="b1" text="b">
+						<d2l-menu id="nestedMenu">
+							<d2l-menu-item id="a2"></d2l-menu-item>
+							<d2l-menu-item id="b2"></d2l-menu-item>
+						</d2l-menu>
+					</d2l-menu-item>
+					<d2l-menu-item id="c1"></d2l-menu-item>
+				</d2l-menu>
+			</template>
+		</test-fixture>
+
 		<script>
 
 		describe('<d2l-menu>', function() {
 
-			it('placeholder test', function() {
-				expect(true).to.be.true;
+			var menu;
+
+			describe('basic menu', function() {
+
+				beforeEach(function() {
+					menu = fixture('basicMenu');
+				});
+
+				it('has role="menu"', function() {
+					expect(menu.getAttribute('role')).to.equal('menu');
+				});
+
+				it('has aria-label equal to label text', function() {
+					expect(menu.getAttribute('aria-label')).to.equal('menu label');
+				});
+
+				it('has 2 menu items', function() {
+					expect(menu.querySelectorAll('d2l-menu-item').length).to.equal(2);
+				});
+
+			});
+
+			describe('nested menu', function() {
+
+				beforeEach(function() {
+					menu = fixture('nestedMenu');
+				});
+
+				it('sets label for nested menu to the opener item text', function() {
+					expect(menu.querySelector('#nestedMenu').getAttribute('aria-label')).to.equal('b');
+				});
+
+				it('shows nested menu when opener is clicked', function(done) {
+					menu.addEventListener('show-complete', function() {
+						expect(menu.querySelector('#nestedMenu').isActive()).to.be.true;
+						done();
+					});
+					menu.querySelector('#b1').click();
+				});
+
+				it('sets focus to d2l-menu-item-return when nested menu is displayed', function(done) {
+					menu.addEventListener('show-complete', function() {
+						expect(document.activeElement.tagName).to.equal('D2L-MENU-ITEM-RETURN');
+						done();
+					});
+					menu.querySelector('#b1').click();
+				});
+
+				it('shows nested menu when right arrow is pressed on opener', function(done) {
+					menu.addEventListener('show-complete', function() {
+						expect(menu.querySelector('#nestedMenu').isActive()).to.be.true;
+						done();
+					});
+					MockInteractions.keyDownOn(menu.querySelector('#b1'), 39);
+				});
+
+				it('hides nested menu when left arrow is pressed in nested menu', function(done) {
+					menu.addEventListener('hide-complete', function() {
+						expect(menu.isActive()).to.be.true;
+						done();
+					});
+					menu.addEventListener('show-complete', function() {
+						MockInteractions.keyDownOn(menu.querySelector('#b2'), 37);
+					});
+					menu.querySelector('#b1').click();
+				});
+
+				it('hides nested menu when escape is pressed in nested menu', function(done) {
+					menu.addEventListener('hide-complete', function() {
+						expect(menu.isActive()).to.be.true;
+						done();
+					});
+					menu.addEventListener('show-complete', function() {
+						MockInteractions.keyDownOn(menu.querySelector('#a2'), 27);
+					});
+					menu.querySelector('#b1').click();
+				});
+
+				it('hides nested menu when d2l-menu-item-return is clicked', function(done) {
+					menu.addEventListener('hide-complete', function() {
+						expect(menu.isActive()).to.be.true;
+						done();
+					});
+					menu.addEventListener('show-complete', function() {
+						document.activeElement.click();
+					});
+					menu.querySelector('#b1').click();
+				});
+
+			});
+
+			describe('focus management', function() {
+
+				/* helper needed since MockInteractions does not set charCode */
+				var keyPressOn = function(target, keyCode) {
+					var e = MockInteractions.keyboardEventFor('keypress', keyCode);
+					e.charCode = keyCode;
+					target.dispatchEvent(e);
+				};
+
+				beforeEach(function() {
+					menu = fixture('focusMenu');
+				});
+
+				it('sets tabindex equal to 0 for first menu item', function() {
+					expect(menu.querySelector('#a1').getAttribute('tabindex')).to.equal('0');
+				});
+
+				it('sets tabindex equal to -1 for hidden menu item', function() {
+					expect(menu.querySelector('#hidden_a').getAttribute('tabindex')).to.equal('-1');
+				});
+
+				it('sets tabindex equal to -1 for menu items after first menu item', function() {
+					var items = menu.querySelector('d2l-menu-item');
+					for(var i=1; i<items.length; i++) {
+						expect(item.getAttribute('tabindex')).to.equal('-1');
+					}
+				});
+
+				it('focus method sets focus to first visible menu item', function() {
+					menu.focus();
+					expect(document.activeElement).to.equal(menu.querySelector('#a1'));
+				});
+
+				it('down arrow moves focus to next focusable item', function() {
+					MockInteractions.keyDownOn(menu.querySelector('#c1'), 40);
+					expect(document.activeElement).to.equal(menu.querySelector('#d1'));
+				});
+
+				it('up arrow moves focus to previous focusable item', function() {
+					MockInteractions.keyDownOn(menu.querySelector('#d1'), 38);
+					expect(document.activeElement).to.equal(menu.querySelector('#c1'));
+				});
+
+				it('down arrow on last focusable item moves focus to first focusable item', function() {
+					MockInteractions.keyDownOn(menu.querySelector('#d1'), 40);
+					expect(document.activeElement).to.equal(menu.querySelector('#a1'));
+				});
+
+				it('up arrow on first focusable item moves focus to last focusable item', function() {
+					MockInteractions.keyDownOn(menu.querySelector('#a1'), 38);
+					expect(document.activeElement).to.equal(menu.querySelector('#d1'));
+				});
+
+				it('sets focus to disabled menu items', function() {
+					MockInteractions.keyDownOn(menu.querySelector('#a1'), 40);
+					expect(document.activeElement).to.equal(menu.querySelector('#b1'));
+				});
+
+				it('sets focus to next item that starts with character pressed', function() {
+					keyPressOn(menu.querySelector('#a1'), 99); /* "c" */
+					expect(document.activeElement).to.equal(menu.querySelector('#c1'));
+				});
+
+				it('sets focus by rolling over to beginning of menu when searching if necessary', function() {
+					keyPressOn(menu.querySelector('#c1'), 98); /* "b" */
+					expect(document.activeElement).to.equal(menu.querySelector('#b1'));
+				});
+
 			});
 
 		});


### PR DESCRIPTION
Adds tests for the bulk of the menu / menu-item logic.

Also includes minor fix to handle case where first menu-item is hidden.

Provide private method for accessing the return menu item element for easier testing with shadow-DOM enabled.