### PR TITLE
Don't stop propagation of events

### DIFF
--- a/d2l-menu-item-selectable-behavior.html
+++ b/d2l-menu-item-selectable-behavior.html
@@ -19,9 +19,7 @@
 			value: String
 		},
 
-		__onSelect: function(e) {
-			e.preventDefault();
-			e.stopPropagation();
+		__onSelect: function() {
 			this.fire('d2l-menu-item-change', {
 				value: this.value,
 				selected: this.selected


### PR DESCRIPTION
This was causing problems with d2l-dropdown-menu, since the selection event was being stopped and therefore the menu wasn't closing. See also https://github.com/Brightspace/d2l-dropdown-ui/pull/84/files