### PR TITLE
Prevent default behavior

### DIFF
--- a/d2l-menu-item-behavior.html
+++ b/d2l-menu-item-behavior.html
@@ -126,6 +126,7 @@
 			}
 			if (e.keyCode === this.__keyCodes.ENTER || e.keyCode === this.__keyCodes.SPACE) {
 				e.stopPropagation();
+				e.preventDefault();
 				this.__action();
 				return;
 			}


### PR DESCRIPTION
Previously:
- Open menu
- Select item using Enter key
- Menu closes
- Enter event goes to menu opener
- Menu opens

Now, the event's default behavior doesn't happen, so the menu item is selected, the menu is closed, and that's it.