### PR TITLE
Update menu-item font-size and height.

### DIFF
--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -15,10 +15,10 @@
 			:host > a {
 				color: inherit;
 				display: block;
-				line-height: 1.2rem;
+				line-height: 1rem;
 				outline: none;
 				overflow-x: hidden;
-				padding: 0.9rem 1rem;
+				padding: 0.75rem 1rem;
 				text-decoration: none;
 				text-overflow: ellipsis;
 				white-space: nowrap;

--- a/d2l-menu-item-return.html
+++ b/d2l-menu-item-return.html
@@ -11,12 +11,12 @@
 
 			:host {
 				display: flex;
-				padding: 0.9rem 1rem;
+				padding: 0.75rem 1rem;
 			}
 
 			:host > span {
 				flex: auto;
-				line-height: 1.2rem;
+				line-height: 1rem;
 				overflow-x: hidden;
 				overflow-y: hidden;
 				text-decoration: none;
@@ -27,7 +27,7 @@
 			:host > d2l-icon {
 				flex: none;
 				margin-right: 1rem;
-				margin-top: 0.2rem;
+				margin-top: 0.1rem;
 			}
 
 			:host-context([dir="rtl"]) > d2l-icon {

--- a/d2l-menu-item-selectable-styles.html
+++ b/d2l-menu-item-selectable-styles.html
@@ -7,13 +7,13 @@
 		<style include="d2l-menu-item-styles">
 			:host {
 				display: flex;
-				padding: 0.9rem 1rem;
+				padding: 0.75rem 1rem;
 				align-items: center
 			}
 
 			:host > span {
 				flex: auto;
-				line-height: 1.2rem;
+				line-height: 1rem;
 				overflow-x: hidden;
 				overflow-y: hidden;
 				text-decoration: none;

--- a/d2l-menu-item-styles.html
+++ b/d2l-menu-item-styles.html
@@ -10,6 +10,7 @@
 				box-sizing: border-box;
 				cursor: pointer;
 				display: block;
+				font-size: 0.8rem;
 				outline: none;
 				width: 100%;
 			}

--- a/d2l-menu-item.html
+++ b/d2l-menu-item.html
@@ -11,12 +11,12 @@
 
 			:host {
 				display: flex;
-				padding: 0.9rem 1rem;
+				padding: 0.75rem 1rem;
 			}
 
 			:host > span {
 				flex: auto;
-				line-height: 1.2rem;
+				line-height: 1rem;
 				overflow-x: hidden;
 				overflow-y: hidden;
 				text-overflow: ellipsis;
@@ -25,7 +25,7 @@
 
 			:host > d2l-icon {
 				flex: none;
-				margin-top: 0.2rem;
+				margin-top: 0.1rem;
 			}
 
 		</style>

--- a/demo/demo-components.html
+++ b/demo/demo-components.html
@@ -10,10 +10,10 @@
 		<style include="d2l-menu-item-styles">
 			:host {
 				display: block;
-				padding: 0.9rem 1rem;
+				padding: 0.75rem 1rem;
 			}
 			:host span {
-				line-height: 1.2rem;
+				line-height: 1rem;
 				overflow-x: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;


### PR DESCRIPTION
@njostonehouse : this is the change to update the wc for menu items.

The font-size for menu-items is to be 16px (0.8rem).
The height (excluding the border/separator) is to be 50px (2.5rem).
